### PR TITLE
[BUGFIX] allow for install to proceed after bower conflict

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -205,8 +205,12 @@ UI.prototype.stopProgress = function() {
 UI.prototype.prompt = function(questions, callback) {
   var inquirer = require('inquirer');
 
-  // If no callback was provided, automatically return a promise
-  return inquirer.prompt(questions, callback);
+  return inquirer.prompt(questions).then(function (answer) {
+    if (callback) {
+      callback(answer);
+    }
+    return answer;
+  });
 };
 
 /**


### PR DESCRIPTION
This addresses https://github.com/ember-cli/ember-cli/issues/6334
Started working on this a couple months ago and got sidetracked, but would like to get this in as its still a problem with the current ember-cli release, and is currently affecting an addon of mine.

I don't have a test to go along because I ran into some trouble simulating cli input into the bower conflict prompt, and there wasn't anything currently testing that.  I can spend some time to add one, if someone has ideas on how to accomplish.  

I did verify that this fixes the use case (with my addon) described in the issue.