### PR TITLE
Fix require error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features:
 ## Usage
 
 ```js
-var UI = require('command-ui')
+var UI = require('console-ui')
 var ui = new UI({
   inputStream: process.stdin,
   outputStream: process.stdout,


### PR DESCRIPTION
The example was requiring `command-ui` instead of `console-ui`. Doh!