### PR TITLE
Extract useful info from errors on writeError & clean up

### DIFF
--- a/lib/write-error.js
+++ b/lib/write-error.js
@@ -1,25 +1,104 @@
 'use strict';
-var chalk = require('chalk');
+const chalk = require('chalk');
 
-module.exports = function writeError(ui, error) {
-  if (!error) { return; }
+function extractBroccoliError(error) {
+  let broccoliPayload = error.broccoliPayload || { error: {} };
+  let broccoliNode = broccoliPayload.broccoliNode || {};
 
-  // Uglify errors have a filename instead
-  var fileName = error.file || error.filename;
-  if (fileName) {
-    if (error.line) {
-      fileName += error.col ? ' (' + error.line + ':' + error.col + ')' : ' (' + error.line + ')';
-    }
-    ui.writeLine(chalk.red('File: ' + fileName), 'ERROR');
+  let defaultLocation = {
+    file: error.file || error.filename, // Uglify errors have `filename` instead
+    line: error.line,
+    column: error.col
+  };
+
+  return {
+    stack: error.stack,
+    broccoliBuilderErrorStack: broccoliPayload.error.stack,
+    errorMessage: error.message,
+    originalErrorMessage: broccoliPayload.error.message,
+    codeFrame: broccoliPayload.error.codeFrame,
+    nodeName: broccoliNode.nodeName,
+    nodeAnnotation: broccoliNode.nodeAnnotation,
+    errorType: broccoliPayload.error.errorType,
+    location: broccoliPayload.error.location || defaultLocation
+  };
+}
+
+// Removes temp folder path from the file name
+function cleanupFileName(fileName) {
+  if (!fileName) {
+    return;
   }
 
-  if (error.message) {
-    ui.writeLine(chalk.red(error.message), 'ERROR');
+  let tmpPosition = fileName.indexOf('.tmp/');
+
+  if (tmpPosition !== -1) {
+    return fileName.substring(tmpPosition + 5);
+  }
+
+  return fileName;
+}
+
+module.exports = function writeError(ui, error) {
+  if (!error) {
+    return;
+  }
+
+  let extracted = extractBroccoliError(error);
+  let stack = extracted.stack;
+  let location = extracted.location;
+  let codeFrame = extracted.codeFrame;
+  let originalErrorMessage = extracted.originalErrorMessage;
+  let errorType = extracted.errorType;
+  let nodeName = extracted.nodeName;
+  let errorMessage = extracted.errorMessage;
+
+  let fileName = cleanupFileName(location.file);
+  if (fileName) {
+    if (location.line) {
+      fileName += typeof location.column !== 'undefined'
+        ? ':' + location.line + ':' + location.column
+        : ':' + location.line;
+    }
+  }
+
+  let title = '';
+  if (errorType) {
+    title = errorType
+
+    if (nodeName) {
+      title += ` (${nodeName})`;
+    }
+  }
+
+  if (fileName) {
+    if (title !== '') {
+      title += ` in ${fileName}`;
+    } else {
+      title = `File: ${fileName}`
+    }
+  }
+
+  if (title) {
+    ui.writeLine(chalk.red(title), 'ERROR');
+    ui.writeLine('', 'ERROR'); // Empty line
+  }
+
+  if (codeFrame) {
+    if (originalErrorMessage && originalErrorMessage !== codeFrame) {
+      ui.writeLine(chalk.red(originalErrorMessage), 'ERROR');
+      ui.writeLine('', 'ERROR'); // Empty line
+    }
+
+    ui.writeLine(chalk.red(codeFrame), 'ERROR');
+  } else if (errorMessage) {
+    ui.writeLine(chalk.red(errorMessage), 'ERROR');
   } else {
     ui.writeLine(chalk.red(error), 'ERROR');
   }
+  ui.writeLine('', 'ERROR'); // Empty line
 
-  if (error.stack) {
-    ui.writeLine(error.stack, 'ERROR');
+  if (stack) {
+    ui.writeLine(chalk.red(stack), 'DEBUG');
   }
 };

--- a/tests/helpers/build-error.js
+++ b/tests/helpers/build-error.js
@@ -10,6 +10,7 @@ function BuildError(input) {
   this.line = input.line;
   this.col = input.col;
   this.stack = input.stack;
+  this.broccoliPayload = input.broccoliPayload;
 }
 
 BuildError.prototype = Object.create(Error.prototype);

--- a/tests/unit/write-error-test.js
+++ b/tests/unit/write-error-test.js
@@ -27,16 +27,17 @@ describe('writeError', function() {
     }));
 
     expect(ui.output).to.equal('');
-    expect(ui.errors).to.equal(chalk.red('build error') + EOL);
+    expect(ui.errors).to.equal(chalk.red('build error') + EOL + EOL);
   });
 
   it('error with stack', function() {
+    ui.setWriteLevel('DEBUG')
     writeError(ui, new BuildError({
       stack: 'the stack'
     }));
 
-    expect(ui.output).to.equal('');
-    expect(ui.errors).to.equal(chalk.red('Error') + EOL + 'the stack' + EOL);
+    expect(ui.output).to.equal(chalk.red('the stack') + EOL);
+    ui.setWriteLevel('INFO');
   });
 
   it('error with file', function() {
@@ -45,7 +46,7 @@ describe('writeError', function() {
     }));
 
     expect(ui.output).to.equal('');
-    expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+    expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + EOL + chalk.red('Error') + EOL + EOL);
   });
 
   it('error with filename (as from Uglify)', function() {
@@ -54,7 +55,7 @@ describe('writeError', function() {
     }));
 
     expect(ui.output).to.equal('');
-    expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+    expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + EOL + chalk.red('Error') + EOL + EOL);
   });
 
   it('error with file + line', function() {
@@ -64,7 +65,7 @@ describe('writeError', function() {
     }));
 
     expect(ui.output).to.equal('');
-    expect(ui.errors).to.equal(chalk.red('File: the file (the line)') + EOL + chalk.red('Error') + EOL);
+    expect(ui.errors).to.equal(chalk.red('File: the file:the line') + EOL + EOL + chalk.red('Error') + EOL + EOL);
   });
 
   it('error with file + col', function() {
@@ -74,7 +75,7 @@ describe('writeError', function() {
     }));
 
     expect(ui.output).to.equal('');
-    expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + chalk.red('Error') + EOL);
+    expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + EOL + chalk.red('Error') + EOL + EOL);
   });
 
   it('error with file + line + col', function() {
@@ -85,6 +86,105 @@ describe('writeError', function() {
     }));
 
     expect(ui.output).to.equal('');
-    expect(ui.errors).to.equal(chalk.red('File: the file (the line:the col)') + EOL + chalk.red('Error') + EOL);
+    expect(ui.errors).to.equal(chalk.red('File: the file:the line:the col') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+  });
+
+  it('error title: file + line + column + errorType + nodeName', function() {
+    writeError(ui, new BuildError({
+      file: 'index.js',
+      line: '10',
+      col:  '15',
+      broccoliPayload: {
+        broccoliNode: {
+          nodeName: 'Babel'
+        },
+        error: {
+          errorType: 'Compile Error'
+        }
+      },
+    }));
+
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('Compile Error (Babel) in index.js:10:15') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+  });
+
+  it('error title: errorType + nodeName', function() {
+    writeError(ui, new BuildError({
+      broccoliPayload: {
+        broccoliNode: {
+          nodeName: 'Babel'
+        },
+        error: {
+          errorType: 'Compile Error'
+        }
+      },
+    }));
+
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('Compile Error (Babel)') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+  });
+
+  it('error title: errorType', function() {
+    writeError(ui, new BuildError({
+      broccoliPayload: {
+        error: {
+          errorType: 'Compile Error'
+        }
+      },
+    }));
+
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('Compile Error') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+  });
+
+  it('error codeFrame', function() {
+    writeError(ui, new BuildError({
+      broccoliPayload: {
+        error: {
+          errorType: 'Compile Error',
+          codeFrame: 'codeFrame'
+        }
+      },
+    }));
+
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(
+      chalk.red('Compile Error') + EOL + EOL +
+      chalk.red('codeFrame') + EOL + EOL);
+  });
+
+  it('error codeFrame with same error message', function() {
+    writeError(ui, new BuildError({
+      broccoliPayload: {
+        error: {
+          errorType: 'Compile Error',
+          codeFrame: 'codeFrame',
+          message: 'codeFrame'
+        }
+      },
+    }));
+
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(
+      chalk.red('Compile Error') + EOL + EOL +
+      chalk.red('codeFrame') + EOL + EOL);
+  });
+
+  it('error codeFrame with different error message', function() {
+    writeError(ui, new BuildError({
+      broccoliPayload: {
+        error: {
+          errorType: 'Compile Error',
+          codeFrame: 'codeFrame',
+          message: 'broccoli error message'
+        }
+      },
+    }));
+
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(
+      chalk.red('Compile Error') + EOL + EOL +
+      chalk.red('broccoli error message') + EOL + EOL +
+      chalk.red('codeFrame') + EOL + EOL);
   });
 });


### PR DESCRIPTION
This is a work in progress to improve error messages in the terminal. Looking for comments and feedback if this is the right direction.

We recently got a nice error page in [broccoli-middleware](https://github.com/ember-cli/broccoli-middleware/pull/25), this PR brings some of that same approach to the console.

## TODO
- [x] Write tests with errors containing `broccoliPayload`
- [x] Fix any broken tests
- [x] Make sure we are always showing error info (not swallowing any error messages)

## Open questions

- Is the idea of `cleanupFileName` the right direction and in the right place? (This will remove the tmp path from the file name for a cleaner user feedback.)
- I changed the stack log from error to  debug to hide it. I could not find a way to should debug messages. Should we create something like `ember s --debug`? 
- I moved the stack logs out because they are very noise, and usually for end users, these stack logs don't provide much value. Is that a good assumption? If we profile a way to show the debug info, I think this would cover power users use cases.

To be able to always (when available) show the file location line & column, I created a [PR in broccoli-builder](https://github.com/ember-cli/broccoli-builder/pull/19) to make sure we passing that info down with `broccoliPayload`. 

**Here is how it looks like with annotation of where the info is coming from:**

![image_2017-09-25_at_9_59_55_am](https://user-images.githubusercontent.com/230476/30822551-0ba23248-a1de-11e7-8be3-62ce83c37436.png)
