### PR TITLE
Add error stack back to main loggin output

### DIFF
--- a/lib/write-error.js
+++ b/lib/write-error.js
@@ -99,6 +99,6 @@ module.exports = function writeError(ui, error) {
   ui.writeLine('', 'ERROR'); // Empty line
 
   if (stack) {
-    ui.writeLine(chalk.red(stack), 'DEBUG');
+    ui.writeLine(stack, 'ERROR');
   }
 };

--- a/tests/unit/write-error-test.js
+++ b/tests/unit/write-error-test.js
@@ -31,13 +31,12 @@ describe('writeError', function() {
   });
 
   it('error with stack', function() {
-    ui.setWriteLevel('DEBUG')
     writeError(ui, new BuildError({
       stack: 'the stack'
     }));
 
-    expect(ui.output).to.equal(chalk.red('the stack') + EOL);
-    ui.setWriteLevel('INFO');
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('Error') + EOL + EOL + 'the stack' + EOL);
   });
 
   it('error with file', function() {


### PR DESCRIPTION
I had removed the error stack from the output in the PR #14, but that limits our ability to debug errors when developing add-ons and such. This is a quick fix to add it back, we should work in a better solution soon.

<img width="1400" alt="screen shot 2017-11-24 at 2 04 45 pm" src="https://user-images.githubusercontent.com/230476/33224687-138877ac-d121-11e7-811e-9afab659d561.png">


cc/ @stefanpenner 