### PR TITLE
Report Detailed Error Reports to disk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "6"
   - "7"
   - "8"
+  - "9"
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ environment:
   matrix:
     - nodejs_version: "4"
     - nodejs_version: "6"
+    - nodejs_version: "8"
+    - nodejs_version: "9"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/index.js
+++ b/lib/index.js
@@ -170,7 +170,7 @@ UI.prototype.writeError = function(error) {
     const filepath = `${tmpdir}/error.dump.${md5}.log`;
 
     fs.writeFileSync(filepath, report);
-    this.writeLine(chalk.red(`Stack Trace and Error Report: ${filepath}`), 'ERROR');
+    this.writeLine(chalk.red(`\nStack Trace and Error Report: ${filepath}`), 'ERROR');
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var ora              = require('ora');
-var EOL              = require('os').EOL;
-var chalk            = require('chalk');
-var writeError       = require('./write-error');
+const ora              = require('ora');
+const EOL              = require('os').EOL;
+const chalk            = require('chalk');
+const writeError       = require('./write-error');
+const tmpdir           = require('os').tmpdir();
+const crypto           = require('crypto');
 
-var DEFAULT_WRITE_LEVEL = 'INFO';
+const DEFAULT_WRITE_LEVEL = 'INFO';
 
 // Note: You should use `ui.outputStream`, `ui.inputStream` and `ui.write()`
 //       instead of `process.stdout` and `console.log`.
@@ -54,6 +56,7 @@ function UI(_options) {
 
   this.errorLog = options.errorLog || [];
   this.writeLevel = options.writeLevel || DEFAULT_WRITE_LEVEL;
+  this.errorReport = null;
   this.ci = !!options.ci;
 }
 
@@ -157,7 +160,15 @@ UI.prototype.prependLine = function(prependData, data, prepend) {
   @param {Error} error
 */
 UI.prototype.writeError = function(error) {
-  writeError(this, error);
+  const report = writeError(this, error);
+  if (report === null) {
+    return;
+  }
+  const md5 = crypto.createHash('md5').update(report).digest("hex");
+  const filepath = `${tmpdir}/error.dump.${md5}.log`;
+
+  fs.writeFileSync(filepath, report);
+  this.writeLine(chalk.red(`Stack Trace and Error Report: ${filepath}`), 'ERROR');
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const chalk            = require('chalk');
 const writeError       = require('./write-error');
 const tmpdir           = require('os').tmpdir();
 const crypto           = require('crypto');
+const fs               = require('fs');
 
 const DEFAULT_WRITE_LEVEL = 'INFO';
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -165,11 +165,13 @@ UI.prototype.writeError = function(error) {
   if (report === null) {
     return;
   }
-  const md5 = crypto.createHash('md5').update(report).digest("hex");
-  const filepath = `${tmpdir}/error.dump.${md5}.log`;
+  if (typeof error === 'object' && error !== null && !error.isSilentError) {
+    const md5 = crypto.createHash('md5').update(report).digest("hex");
+    const filepath = `${tmpdir}/error.dump.${md5}.log`;
 
-  fs.writeFileSync(filepath, report);
-  this.writeLine(chalk.red(`Stack Trace and Error Report: ${filepath}`), 'ERROR');
+    fs.writeFileSync(filepath, report);
+    this.writeLine(chalk.red(`Stack Trace and Error Report: ${filepath}`), 'ERROR');
+  }
 };
 
 /**

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var UI      = require('./');
-var through = require('through');
+const UI      = require('./');
+const through = require('through');
 
 module.exports = MockUI;
 function MockUI(options) {
@@ -20,11 +20,13 @@ function MockUI(options) {
 
   this.output = '';
   this.errors = '';
+  this.errorReport = '';
   this.errorLog = options && options.errorLog || [];
 }
 
 MockUI.prototype = Object.create(UI.prototype);
 MockUI.prototype.constructor = MockUI;
+
 MockUI.prototype.clear = function() {
   this.output = '';
   this.errors = '';

--- a/lib/summarize-process.js
+++ b/lib/summarize-process.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const os = require('os');
+const userInfo = require('user-info');
+
+module.exports = function summarizeProcess(process) {
+  let PATH = [];
+  if (process.env && process.env.PATH) {
+    PATH = process.env.PATH.split(/:/);
+  }
+
+  return`
+  TIME: ${new Date()}
+  TITLE: ${process.title || ''}
+  ARGV:${arr(process.argv || [])}
+  EXEC_PATH: ${process.execPath || ''}
+  TMPDIR: ${os.tmpdir()}
+  SHELL: ${userInfo().shell}
+  PATH:${arr(PATH)}
+  PLATFORM: ${process.platform || ''} ${process.arch || ''}
+  FREEMEM: ${os.freemem()}
+  TOTALMEM: ${os.totalmem()}
+  UPTIME: ${os.uptime()}
+  LOADAVG: ${os.loadavg()}
+  CPUS:${arr(os.cpus().map(cpu => '' + cpu.model + ' - ' + cpu.speed))}
+  ENDIANNESS: ${os.endianness()}
+  VERSIONS:${obj(process.versions)}
+`;
+}
+
+module.exports.obj = obj;
+function obj(o) {
+  if (o === undefined) { return ''; }
+  let depth;
+
+  if (arguments.length < 2) {
+    depth = 0;
+  } else {
+    depth = arguments[1];
+  }
+
+  let indent = '  ';
+  for (let i = 0; i < depth; i++){
+    indent += '  ';
+  }
+
+  let result = Object.keys(o).sort().reduce((acc, key) => {
+    let value = o[key];
+
+    if (value === undefined) {
+      acc += `\n${indent}- ${key}: [undefined]`
+      return acc;
+    } else if (value === null) {
+      acc += `\n${indent}- ${key}: [null]`
+      return acc;
+    }
+
+    if (Array.isArray(value)) {
+      acc += `\n${indent}- ${key}:`;
+      acc += `${arr(value, depth + 1)}`
+    } else if (typeof value === 'object') {
+      acc += `\n${indent}- ${key}:`
+      acc += obj(value, depth + 1);
+    } else {
+      acc += `\n${indent}- ${key}: ${value}`;
+    }
+
+    return acc;
+  }, '');
+
+  if (result === '') {
+      return `\n${indent}- { }`;
+  }
+  return result;
+}
+
+module.exports.arr = arr;
+function arr(array) {
+  let depth = arguments.length < 2 ? '  ' : arguments[1];
+
+  let indent = '  ';
+  for (let i = 0; i < depth; i++){
+    indent += '  ';
+  }
+  return array.reduce((acc, entry) => {
+    if (typeof entry === 'object') {
+      if (entry === null) {
+        acc += `\n${indent}- [null]`;
+      } else {
+        acc += `${obj(entry, depth )}`;
+      }
+    } else {
+      acc += `\n${indent}- ${entry}`
+    }
+    return acc;
+  }, '');
+}
+

--- a/lib/write-error.js
+++ b/lib/write-error.js
@@ -1,5 +1,7 @@
 'use strict';
 const chalk = require('chalk');
+const fs = require('fs');
+const summarizeProcess = require('./summarize-process');
 
 function extractBroccoliError(error) {
   let broccoliPayload = error.broccoliPayload || { error: {} };
@@ -12,6 +14,8 @@ function extractBroccoliError(error) {
   };
 
   return {
+    name: error.name,
+    message: error.message,
     stack: error.stack,
     broccoliBuilderErrorStack: broccoliPayload.error.stack,
     errorMessage: error.message,
@@ -41,7 +45,7 @@ function cleanupFileName(fileName) {
 
 module.exports = function writeError(ui, error) {
   if (!error) {
-    return;
+    return null;
   }
 
   let extracted = extractBroccoliError(error);
@@ -99,6 +103,16 @@ module.exports = function writeError(ui, error) {
   ui.writeLine('', 'ERROR'); // Empty line
 
   if (stack) {
-    ui.writeLine(stack, 'ERROR');
+    ui.writeLine(stack, 'DEBUG');
   }
-};
+
+  return `=================================================================================
+
+ENV Summary:
+${summarizeProcess(process)}
+ERROR Summary:
+${summarizeProcess.obj(extracted)}
+
+=================================================================================
+`;
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "dependencies": {
     "chalk": "^2.1.0",
     "inquirer": "^2",
+    "json-stable-stringify": "^1.0.1",
     "ora": "^1.3.0",
-    "through": "^2.3.8"
+    "through": "^2.3.8",
+    "user-info": "^1.0.0"
   },
   "name": "console-ui",
   "description": "common interface for abstracting a console ui",

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -120,5 +120,16 @@ describe('UI', function() {
       expect(report).to.contain('ERROR Summary:');
       expect(report).to.contain('I AM ERROR MESSAGE');
     });
+
+    it('SilentError', function() {
+      let e = new Error('I AM ERROR MESSAGE');
+      e.isSilentError = true;
+      ui.writeError(e);
+      expect(ui.output).to.eql('');
+      expect(ui.errors).to.contain('I AM ERROR MESSAGE');
+      expect(ui.errors).to.not.contain('Stack Trace and Error Report');
+      expect(ui.errors).to.not.contain('error\.dump\.');
+      expect(ui.errorLog).to.deep.eql([]);
+    });
   });
 });

--- a/tests/unit/summarize-process-test.js
+++ b/tests/unit/summarize-process-test.js
@@ -29,7 +29,7 @@ describe('summarizeProcess', function() {
     expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
     expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
     expect(summary.shift()).to.match(/^  UPTIME: \d+(\.\d+)?$/);
-    expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
+    expect(summary.shift()).to.match(/^  LOADAVG: \d+(\.\d+)?,\d+(\.\d+)?,\d+(\.\d+)?$/);
     expect(summary.shift()).to.match(/^  CPUS:$/);
 
     for (let i = 0; i < require('os').cpus().length; i++) {
@@ -66,7 +66,7 @@ describe('summarizeProcess', function() {
     expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
     expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
     expect(summary.shift()).to.match(/^  UPTIME: \d+(\.\d+)?$/);
-    expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
+    expect(summary.shift()).to.match(/^  LOADAVG: \d+(\.\d+)?,\d+(\.\d+)?,\d+(\.\d+)?$/);
     expect(summary.shift()).to.match(/^  CPUS:$/);
 
     for (let i = 0; i < require('os').cpus().length; i++) {
@@ -99,7 +99,7 @@ describe('summarizeProcess', function() {
     expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
     expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
     expect(summary.shift()).to.match(/^  UPTIME: \d+(\.\d+)?$/);
-    expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
+    expect(summary.shift()).to.match(/^  LOADAVG: \d+(\.\d+)?,\d+(\.\d+)?,\d+(\.\d+)?$/);
     expect(summary.shift()).to.match(/^  CPUS:$/);
 
     for (let i = 0; i < require('os').cpus().length; i++) {
@@ -137,7 +137,7 @@ describe('summarizeProcess', function() {
     expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
     expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
     expect(summary.shift()).to.match(/^  UPTIME: \d+(\.\d+)?$/);
-    expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
+    expect(summary.shift()).to.match(/^  LOADAVG: \d+(\.\d+)?,\d+(\.\d+)?,\d+(\.\d+)?$/);
     expect(summary.shift()).to.match(/^  CPUS:$/);
 
     for (let i = 0; i < require('os').cpus().length; i++) {
@@ -179,8 +179,9 @@ describe('summarizeProcess', function() {
     expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
     expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
     expect(summary.shift()).to.match(/^  UPTIME: \d+(\.\d+)?$/);
-    expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
+    expect(summary.shift()).to.match(/^  LOADAVG: \d+(\.\d+)?,\d+(\.\d+)?,\d+(\.\d+)?$/);
     expect(summary.shift()).to.match(/^  CPUS:$/);
+
 
     for (let i = 0; i < require('os').cpus().length; i++) {
       expect(summary.shift()).to.match(/^  - (.*)$/);

--- a/tests/unit/summarize-process-test.js
+++ b/tests/unit/summarize-process-test.js
@@ -28,7 +28,7 @@ describe('summarizeProcess', function() {
     expect(summary.shift()).to.match(/^  PLATFORM: (.*)\s(.*)$/);
     expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
     expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
-    expect(summary.shift()).to.match(/^  UPTIME: \d+$/);
+    expect(summary.shift()).to.match(/^  UPTIME: \d+(\.\d+)?$/);
     expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
     expect(summary.shift()).to.match(/^  CPUS:$/);
 
@@ -65,7 +65,7 @@ describe('summarizeProcess', function() {
     expect(summary.shift()).to.match(/^  PLATFORM:  $/);
     expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
     expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
-    expect(summary.shift()).to.match(/^  UPTIME: \d+$/);
+    expect(summary.shift()).to.match(/^  UPTIME: \d+(\.\d+)?$/);
     expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
     expect(summary.shift()).to.match(/^  CPUS:$/);
 
@@ -98,7 +98,7 @@ describe('summarizeProcess', function() {
     expect(summary.shift()).to.match(/^  PLATFORM: the-plat the-arc$/);
     expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
     expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
-    expect(summary.shift()).to.match(/^  UPTIME: \d+$/);
+    expect(summary.shift()).to.match(/^  UPTIME: \d+(\.\d+)?$/);
     expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
     expect(summary.shift()).to.match(/^  CPUS:$/);
 
@@ -136,7 +136,7 @@ describe('summarizeProcess', function() {
 
     expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
     expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
-    expect(summary.shift()).to.match(/^  UPTIME: \d+$/);
+    expect(summary.shift()).to.match(/^  UPTIME: \d+(\.\d+)?$/);
     expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
     expect(summary.shift()).to.match(/^  CPUS:$/);
 
@@ -178,7 +178,7 @@ describe('summarizeProcess', function() {
     expect(summary.shift()).to.match(/^  PLATFORM:  $/);
     expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
     expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
-    expect(summary.shift()).to.match(/^  UPTIME: \d+$/);
+    expect(summary.shift()).to.match(/^  UPTIME: \d+(\.\d+)?$/);
     expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
     expect(summary.shift()).to.match(/^  CPUS:$/);
 

--- a/tests/unit/summarize-process-test.js
+++ b/tests/unit/summarize-process-test.js
@@ -1,0 +1,268 @@
+'use strict';
+const summarizeProcess = require('../../lib/summarize-process');
+const obj = summarizeProcess.obj;
+const expect = require('chai').expect;
+
+describe('summarizeProcess', function() {
+  it('acceptance', function() {
+    const summary = summarizeProcess(process).split(/\n/);
+
+    expect(summary.shift()).to.match(/^$/);
+    expect(summary.shift()).to.match(/^  TIME: (.*)$/);
+    expect(summary.shift()).to.match(/^  TITLE: (.*)$/);
+    expect(summary.shift()).to.match(/^  ARGV:$/);
+
+    for (let x = 0 ; x < process.argv.length; x++) {
+      expect(summary.shift()).to.match(/^  -.*/);
+    }
+
+    expect(summary.shift()).to.match(/^  EXEC_PATH: (.*)$/);
+    expect(summary.shift()).to.match(/^  TMPDIR: (.*)$/);
+    expect(summary.shift()).to.match(/^  SHELL: (.*)$/);
+    expect(summary.shift()).to.match(/^  PATH:$/);
+
+    for (let x = 0 ; x < process.env.PATH.split(':').length; x++) {
+      expect(summary.shift()).to.match(/^  -.*/);
+    }
+
+    expect(summary.shift()).to.match(/^  PLATFORM: (.*)\s(.*)$/);
+    expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
+    expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
+    expect(summary.shift()).to.match(/^  UPTIME: \d+$/);
+    expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
+    expect(summary.shift()).to.match(/^  CPUS:$/);
+
+    for (let i = 0; i < require('os').cpus().length; i++) {
+      expect(summary.shift()).to.match(/^  - (.*)$/);
+    }
+
+    expect(summary.shift()).to.match(/^  ENDIANNESS: (.*)$/);
+    expect(summary.shift()).to.match(/^  VERSIONS:$/);
+
+    for (let x = 0 ; x < Object.keys(process.versions).length; x++) {
+      expect(summary.shift()).to.match(/^  -.*/);
+    }
+    expect(summary.shift()).to.match(/^$/);
+    expect(summary).to.be.empty;
+  });
+
+  it('handles an unexpected empty process', function() {
+    const process = {};
+    const summary = summarizeProcess(process).split(/\n/);
+    // doesn't crash
+    //
+    // has expected: "shape"
+    expect(summary.shift()).to.match(/^$/);
+    expect(summary.shift()).to.match(/^  TIME: (.*)$/);
+    expect(summary.shift()).to.match(/^  TITLE: $/);
+    expect(summary.shift()).to.match(/^  ARGV:$/);
+
+    expect(summary.shift()).to.match(/^  EXEC_PATH: $/);
+    expect(summary.shift()).to.match(/^  TMPDIR: (.*)$/);
+    expect(summary.shift()).to.match(/^  SHELL: (.*)$/);
+    expect(summary.shift()).to.match(/^  PATH:$/);
+
+    expect(summary.shift()).to.match(/^  PLATFORM:  $/);
+    expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
+    expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
+    expect(summary.shift()).to.match(/^  UPTIME: \d+$/);
+    expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
+    expect(summary.shift()).to.match(/^  CPUS:$/);
+
+    for (let i = 0; i < require('os').cpus().length; i++) {
+      expect(summary.shift()).to.match(/^  - (.*)$/);
+    }
+
+    expect(summary.shift()).to.match(/^  ENDIANNESS: (.*)$/);
+    expect(summary.shift()).to.match(/^  VERSIONS:$/);
+    expect(summary.shift()).to.match(/^$/);
+    expect(summary).to.be.empty;
+  });
+
+  it('handles arch + platform', function() {
+    const process = {};
+    const summary = summarizeProcess({ arch: 'the-arc', platform: 'the-plat'}).split(/\n/);
+    // doesn't crash
+    //
+    // has expected: "shape"
+    expect(summary.shift()).to.match(/^$/);
+    expect(summary.shift()).to.match(/^  TIME: (.*)$/);
+    expect(summary.shift()).to.match(/^  TITLE: $/);
+    expect(summary.shift()).to.match(/^  ARGV:$/);
+
+    expect(summary.shift()).to.match(/^  EXEC_PATH: $/);
+    expect(summary.shift()).to.match(/^  TMPDIR: (.*)$/);
+    expect(summary.shift()).to.match(/^  SHELL: (.*)$/);
+    expect(summary.shift()).to.match(/^  PATH:$/);
+
+    expect(summary.shift()).to.match(/^  PLATFORM: the-plat the-arc$/);
+    expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
+    expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
+    expect(summary.shift()).to.match(/^  UPTIME: \d+$/);
+    expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
+    expect(summary.shift()).to.match(/^  CPUS:$/);
+
+    for (let i = 0; i < require('os').cpus().length; i++) {
+      expect(summary.shift()).to.match(/^  - (.*)$/);
+    }
+
+    expect(summary.shift()).to.match(/^  ENDIANNESS: (.*)$/);
+    expect(summary.shift()).to.match(/^  VERSIONS:$/);
+    expect(summary.shift()).to.match(/^$/);
+    expect(summary).to.be.empty;
+  });
+
+  it('handles versions', function() {
+    const process = {};
+    const summary = summarizeProcess({
+      versions: {
+        o: 1,
+        my: 2,
+        gosh: 3,
+      }
+    }).split(/\n/);
+
+    expect(summary.shift()).to.match(/^$/);
+    expect(summary.shift()).to.match(/^  TIME: (.*)$/);
+    expect(summary.shift()).to.match(/^  TITLE: $/);
+    expect(summary.shift()).to.match(/^  ARGV:$/);
+
+    expect(summary.shift()).to.match(/^  EXEC_PATH: $/);
+    expect(summary.shift()).to.match(/^  TMPDIR: (.*)$/);
+    expect(summary.shift()).to.match(/^  SHELL: (.*)$/);
+    expect(summary.shift()).to.match(/^  PATH:$/);
+
+    expect(summary.shift()).to.match(/^  PLATFORM:  $/);
+
+    expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
+    expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
+    expect(summary.shift()).to.match(/^  UPTIME: \d+$/);
+    expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
+    expect(summary.shift()).to.match(/^  CPUS:$/);
+
+    for (let i = 0; i < require('os').cpus().length; i++) {
+      expect(summary.shift()).to.match(/^  - (.*)$/);
+    }
+
+    expect(summary.shift()).to.match(/^  ENDIANNESS: (.*)$/);
+
+    expect(summary.shift()).to.match(/^  VERSIONS:$/);
+    expect(summary.shift()).to.match(/^  - gosh: 3$/);
+    expect(summary.shift()).to.match(/^  - my: 2$/);
+    expect(summary.shift()).to.match(/^  - o: 1$/);
+    expect(summary.shift()).to.match(/^$/);
+    expect(summary).to.be.empty;
+  });
+
+  it('handles PATH', function() {
+    const process = {};
+    const summary = summarizeProcess({
+      env: {
+        PATH: 'one:two:three'
+      }
+    }).split(/\n/);
+
+    expect(summary.shift()).to.match(/^$/);
+    expect(summary.shift()).to.match(/^  TIME: (.*)$/);
+    expect(summary.shift()).to.match(/^  TITLE: $/);
+    expect(summary.shift()).to.match(/^  ARGV:$/);
+
+    expect(summary.shift()).to.match(/^  EXEC_PATH: $/);
+    expect(summary.shift()).to.match(/^  TMPDIR: (.*)$/);
+    expect(summary.shift()).to.match(/^  SHELL: (.*)$/);
+    expect(summary.shift()).to.match(/^  PATH:$/);
+    expect(summary.shift()).to.match(/^  - one$/);
+    expect(summary.shift()).to.match(/^  - two$/);
+    expect(summary.shift()).to.match(/^  - three$/);
+
+    expect(summary.shift()).to.match(/^  PLATFORM:  $/);
+    expect(summary.shift()).to.match(/^  FREEMEM: \d+$/);
+    expect(summary.shift()).to.match(/^  TOTALMEM: \d+$/);
+    expect(summary.shift()).to.match(/^  UPTIME: \d+$/);
+    expect(summary.shift()).to.match(/^  LOADAVG: \d+.\d+,\d+.\d+,\d+.\d+$/);
+    expect(summary.shift()).to.match(/^  CPUS:$/);
+
+    for (let i = 0; i < require('os').cpus().length; i++) {
+      expect(summary.shift()).to.match(/^  - (.*)$/);
+    }
+
+    expect(summary.shift()).to.match(/^  ENDIANNESS: (.*)$/);
+
+    expect(summary.shift()).to.match(/^  VERSIONS:$/);
+    expect(summary.shift()).to.match(/^$/);
+    expect(summary).to.be.empty;
+  });
+
+  describe('obj', function() {
+    it('nested obj', function() {
+      expect(obj({
+        nested: {
+          obj: {
+            obj: {
+              obj: {
+                obj: 2
+              }
+            }
+          }
+        }
+      })).to.eql(`
+  - nested:
+    - obj:
+      - obj:
+        - obj:
+          - obj: 2`
+      );
+    });
+
+    it('nested array', function() {
+      expect(obj({
+        obj: {
+          avalue: [1,2,3, { foo: 1}],
+          bnested: {
+            deeper: [1,2,3, { foo: 1}],
+          },
+        }
+      })).to.eql(`
+  - obj:
+    - avalue:
+      - 1
+      - 2
+      - 3
+      - foo: 1
+    - bnested:
+      - deeper:
+        - 1
+        - 2
+        - 3
+        - foo: 1`);
+    });
+
+    it('complex', function() {
+      expect(obj({
+        ARGV: [1,2,3, {}, null],
+        ENV: null,
+        title: 'hi',
+        PATH: 'hi:hi:hi',
+        nested: {
+          obj: {
+            obj: 2,
+          }
+        }
+      })).to.eql(`
+  - ARGV:
+    - 1
+    - 2
+    - 3
+    - { }
+    - [null]
+  - ENV: [null]
+  - PATH: hi:hi:hi
+  - nested:
+    - obj:
+      - obj: 2
+  - title: hi`
+      );
+    });
+  });
+});
+

--- a/tests/unit/write-error-test.js
+++ b/tests/unit/write-error-test.js
@@ -1,84 +1,102 @@
 'use strict';
 
-var expect     = require('chai').expect;
-var writeError = require('../../lib/write-error');
-var MockUI     = require('../../lib/mock');
-var BuildError = require('../helpers/build-error');
-var EOL        = require('os').EOL;
-var chalk      = require('chalk');
+const expect     = require('chai').expect;
+const writeError = require('../../lib/write-error');
+const MockUI     = require('../../lib/mock');
+const BuildError = require('../helpers/build-error');
+const EOL        = require('os').EOL;
+const chalk      = require('chalk');
 
 describe('writeError', function() {
-  var ui;
+  let ui;
 
   beforeEach(function() {
     ui = new MockUI();
   });
 
   it('no error', function() {
-    writeError(ui);
+    let report = writeError(ui);
 
     expect(ui.output).to.equal('');
     expect(ui.errors).to.equal('');
+    expect(report).to.equal(null);
   });
 
   it('error with message', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       message: 'build error'
     }));
 
     expect(ui.output).to.equal('');
     expect(ui.errors).to.equal(chalk.red('build error') + EOL + EOL);
+
+    expect(report).to.contain('ENV Summary:');
+    expect(report).to.contain('ERROR Summary:');
+    expect(report).to.contain('message: build error');
+    expect(report).to.contain('stack: [undefined]');
+    expect(report).to.contain('TIME: ');
   });
 
   it('error with stack', function() {
-    writeError(ui, new BuildError({
+    ui.setWriteLevel('DEBUG');
+    let report = writeError(ui, new BuildError({
       stack: 'the stack'
     }));
 
-    expect(ui.output).to.equal('');
-    expect(ui.errors).to.equal(chalk.red('Error') + EOL + EOL + 'the stack' + EOL);
+    expect(ui.output).to.equal('the stack\n');
+    expect(ui.errors).to.equal(chalk.red('Error') + EOL + EOL);
+    expect(report).to.contain('message: [undefined]');
+    expect(report).to.contain('stack: the stack');
   });
 
   it('error with file', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       file: 'the file'
     }));
 
     expect(ui.output).to.equal('');
     expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+
+    expect(report).to.contain('file: the file');
   });
 
   it('error with filename (as from Uglify)', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       filename: 'the file'
     }));
 
     expect(ui.output).to.equal('');
     expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+    expect(report).to.contain('file: the file');
   });
 
   it('error with file + line', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       file: 'the file',
       line: 'the line'
     }));
 
     expect(ui.output).to.equal('');
     expect(ui.errors).to.equal(chalk.red('File: the file:the line') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+    expect(report).to.contain('file: the file');
+    expect(report).to.contain('line: the line');
   });
 
   it('error with file + col', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       file: 'the file',
       col: 'the col'
     }));
 
     expect(ui.output).to.equal('');
     expect(ui.errors).to.equal(chalk.red('File: the file') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+
+    expect(report).to.contain('file: the file');
+    expect(report).to.contain('column: the col');
   });
 
   it('error with file + line + col', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       file: 'the file',
       line: 'the line',
       col:  'the col'
@@ -86,10 +104,13 @@ describe('writeError', function() {
 
     expect(ui.output).to.equal('');
     expect(ui.errors).to.equal(chalk.red('File: the file:the line:the col') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+    expect(report).to.contain('file: the file');
+    expect(report).to.contain('line: the line');
+    expect(report).to.contain('column: the col');
   });
 
   it('error title: file + line + column + errorType + nodeName', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       file: 'index.js',
       line: '10',
       col:  '15',
@@ -105,10 +126,17 @@ describe('writeError', function() {
 
     expect(ui.output).to.equal('');
     expect(ui.errors).to.equal(chalk.red('Compile Error (Babel) in index.js:10:15') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+
+
+    expect(report).to.contain('file: index.js');
+    expect(report).to.contain('line: 10');
+    expect(report).to.contain('column: 15');
+    expect(report).to.contain('Babel');
+    expect(report).to.contain('Compile Error');
   });
 
   it('error title: errorType + nodeName', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       broccoliPayload: {
         broccoliNode: {
           nodeName: 'Babel'
@@ -121,10 +149,13 @@ describe('writeError', function() {
 
     expect(ui.output).to.equal('');
     expect(ui.errors).to.equal(chalk.red('Compile Error (Babel)') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+
+    expect(report).to.contain('Babel');
+    expect(report).to.contain('Compile Error');
   });
 
   it('error title: errorType', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       broccoliPayload: {
         error: {
           errorType: 'Compile Error'
@@ -134,10 +165,12 @@ describe('writeError', function() {
 
     expect(ui.output).to.equal('');
     expect(ui.errors).to.equal(chalk.red('Compile Error') + EOL + EOL + chalk.red('Error') + EOL + EOL);
+
+    expect(report).to.contain('Compile Error');
   });
 
   it('error codeFrame', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       broccoliPayload: {
         error: {
           errorType: 'Compile Error',
@@ -150,10 +183,13 @@ describe('writeError', function() {
     expect(ui.errors).to.equal(
       chalk.red('Compile Error') + EOL + EOL +
       chalk.red('codeFrame') + EOL + EOL);
+
+    expect(report).to.contain('Compile Error');
+    expect(report).to.contain('codeFrame');
   });
 
   it('error codeFrame with same error message', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       broccoliPayload: {
         error: {
           errorType: 'Compile Error',
@@ -167,10 +203,13 @@ describe('writeError', function() {
     expect(ui.errors).to.equal(
       chalk.red('Compile Error') + EOL + EOL +
       chalk.red('codeFrame') + EOL + EOL);
+
+    expect(report).to.contain('Compile Error');
+    expect(report).to.contain('codeFrame');
   });
 
   it('error codeFrame with different error message', function() {
-    writeError(ui, new BuildError({
+    let report = writeError(ui, new BuildError({
       broccoliPayload: {
         error: {
           errorType: 'Compile Error',
@@ -185,5 +224,9 @@ describe('writeError', function() {
       chalk.red('Compile Error') + EOL + EOL +
       chalk.red('broccoli error message') + EOL + EOL +
       chalk.red('codeFrame') + EOL + EOL);
+
+    expect(report).to.contain('Compile Error');
+    expect(report).to.contain('codeFrame');
+    expect(report).to.contain('broccoli error message');
   });
 });

--- a/tests/unit/write-error-test.js
+++ b/tests/unit/write-error-test.js
@@ -43,7 +43,7 @@ describe('writeError', function() {
       stack: 'the stack'
     }));
 
-    expect(ui.output).to.equal('the stack\n');
+    expect(ui.output).to.equal('the stack' + EOL);
     expect(ui.errors).to.equal(chalk.red('Error') + EOL + EOL);
     expect(report).to.contain('message: [undefined]');
     expect(report).to.contain('stack: the stack');

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,10 @@ ansi-styles@^3.1.0:
   dependencies:
     color-convert "^1.9.0"
 
+array-find-index@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+
 assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
@@ -42,6 +46,21 @@ brace-expansion@^1.1.7:
 browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+
+builtin-modules@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+camelcase-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
+  dependencies:
+    camelcase "^2.0.0"
+    map-obj "^1.0.0"
+
+camelcase@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
 chai@^4.1.1:
   version "4.1.2"
@@ -126,11 +145,21 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+currently-unhandled@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
+  dependencies:
+    array-find-index "^1.0.1"
+
 debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
+
+decamelize@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
 deep-eql@^3.0.0:
   version "3.0.1"
@@ -142,9 +171,23 @@ diff@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
 
+error-ex@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  dependencies:
+    is-arrayish "^0.2.1"
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+exec-file-sync@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/exec-file-sync/-/exec-file-sync-2.0.2.tgz#58d441db46e40de6d1f30de5be022785bd89e328"
+  dependencies:
+    is-obj "^1.0.0"
+    object-assign "^4.0.1"
+    spawn-sync "^1.0.11"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -168,6 +211,13 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -175,6 +225,10 @@ fs.realpath@^1.0.0:
 get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+
+get-stdin@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
 glob@7.1.2:
   version "7.1.2"
@@ -186,6 +240,10 @@ glob@7.1.2:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+graceful-fs@^4.1.2:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
 growl@1.10.3:
   version "1.10.3"
@@ -204,6 +262,16 @@ has-flag@^2.0.0:
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+hosted-git-info@^2.1.4:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
+
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  dependencies:
+    repeating "^2.0.0"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -235,17 +303,61 @@ inquirer@^2:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
+
+is-finite@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
+  dependencies:
+    number-is-nan "^1.0.0"
+
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
+is-utf8@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  dependencies:
+    jsonify "~0.0.0"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+
+load-json-file@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    strip-bom "^2.0.0"
 
 lodash@^4.3.0:
   version "4.17.4"
@@ -256,6 +368,32 @@ log-symbols@^1.0.2:
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
   dependencies:
     chalk "^1.0.0"
+
+loud-rejection@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
+  dependencies:
+    currently-unhandled "^0.4.1"
+    signal-exit "^3.0.0"
+
+map-obj@^1.0.0, map-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+meow@^3.4.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
+  dependencies:
+    camelcase-keys "^2.0.0"
+    decamelize "^1.1.2"
+    loud-rejection "^1.0.0"
+    map-obj "^1.0.1"
+    minimist "^1.1.3"
+    normalize-package-data "^2.3.4"
+    object-assign "^4.0.1"
+    read-pkg-up "^1.0.1"
+    redent "^1.0.0"
+    trim-newlines "^1.0.0"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -270,6 +408,10 @@ minimatch@^3.0.4:
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@^1.1.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
 mkdirp@0.5.1:
   version "0.5.1"
@@ -300,6 +442,23 @@ mute-stream@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
 
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+
+object-assign@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -325,6 +484,10 @@ ora@^1.3.0:
     cli-spinners "^1.0.0"
     log-symbols "^1.0.2"
 
+os-homedir@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+
 os-shim@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
@@ -333,13 +496,43 @@ os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  dependencies:
+    error-ex "^1.2.0"
+
+passwd-user@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/passwd-user/-/passwd-user-1.2.1.tgz#a01a5dc639ef007dc56364b8178569080ad3a7b8"
+  dependencies:
+    exec-file-sync "^2.0.0"
+
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  dependencies:
+    pinkie-promise "^2.0.0"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-type@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
+  dependencies:
+    graceful-fs "^4.1.2"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 pathval@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
+pify@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -355,6 +548,21 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+read-pkg-up@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
+  dependencies:
+    find-up "^1.0.0"
+    read-pkg "^1.0.0"
+
+read-pkg@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
+  dependencies:
+    load-json-file "^1.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^1.0.0"
+
 readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
@@ -366,6 +574,19 @@ readable-stream@^2.2.2:
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
+
+redent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
+  dependencies:
+    indent-string "^2.1.0"
+    strip-indent "^1.0.1"
+
+repeating@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
+  dependencies:
+    is-finite "^1.0.0"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -395,16 +616,34 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-signal-exit@^3.0.2:
+"semver@2 || 3 || 4 || 5":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-spawn-sync@^1.0.15:
+spawn-sync@^1.0.11, spawn-sync@^1.0.15:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
   dependencies:
     concat-stream "^1.4.7"
     os-shim "^0.1.2"
+
+spdx-correct@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+  dependencies:
+    spdx-license-ids "^1.0.2"
+
+spdx-expression-parse@~1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+
+spdx-license-ids@^1.0.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
 string-width@^2.0.0:
   version "2.1.1"
@@ -430,6 +669,18 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-bom@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
+  dependencies:
+    is-utf8 "^0.2.0"
+
+strip-indent@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
+  dependencies:
+    get-stdin "^4.0.1"
 
 supports-color@4.4.0:
   version "4.4.0"
@@ -457,6 +708,10 @@ tmp@^0.0.29:
   dependencies:
     os-tmpdir "~1.0.1"
 
+trim-newlines@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
+
 type-detect@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
@@ -465,9 +720,30 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+user-info@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/user-info/-/user-info-1.0.0.tgz#81c82b7ed63e674c2475667653413b3c76fde239"
+  dependencies:
+    os-homedir "^1.0.1"
+    passwd-user "^1.2.1"
+    username "^1.0.1"
+
+username@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/username/-/username-1.0.1.tgz#e1f72295e3e58e06f002c6327ce06897a99cd67f"
+  dependencies:
+    meow "^3.4.0"
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  dependencies:
+    spdx-correct "~1.0.0"
+    spdx-expression-parse "~1.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This aims to restore debuggability we lost from https://github.com/ember-cli/console-ui/pull/14 (but maintain the improved day 2 day ergonomics improved by #14)

the error report ends up having a filepath of the following format:
```
<tmpdir>/error.dump.<checksum-of-the-repo>.log
```

Why?

* cleanup after themselves
* doesn't conflict, and doesn't pollute cwd
* configurable via `TMPDIR`

Alternatives:

* local `tmp` or `log`
* system `log` ?

Example filepath:

```
/private/var/folders/4r/whc65vwj1xggvvky3yy1cp9m000mw4/T/error.dump.1c7e928964050f90db424cbdaef761ec.log
```


the error reports end up looking like:

```
=================================================================================

ENV Summary:

  TIME: Fri Nov 24 2017 18:54:14 GMT-0800 (PST)
  TITLE: node
  ARGV:
  - /Users/spenner/src/stefanpenner/dotfiles/.config/node/versions/node-v8.9.0-darwin-x64/bin/node
  EXEC_PATH: /Users/spenner/src/stefanpenner/dotfiles/.config/node/versions/node-v8.9.0-darwin-x64/bin/node
  PATH:
  - /Users/spenner/.fzf/bin
  - /Users/spenner/.cargo/bin
  - /Users/spenner/.config/node/default/bin
  - /usr/local/bin
  - /usr/bin
  - /bin
  - /usr/sbin
  - /sbin
  - /usr/local/linkedin/bin
  - /export/content/linkedin/bin
  PLATFORM: darwin x64
  VERSIONS:
  - ares: 1.10.1-DEV
  - cldr: 31.0.1
  - http_parser: 2.7.0
  - icu: 59.1
  - modules: 57
  - nghttp2: 1.25.0
  - node: 8.9.0
  - openssl: 1.0.2l
  - tz: 2017b
  - unicode: 9.0
  - uv: 1.15.0
  - v8: 6.1.534.46
  - zlib: 1.2.11

ERROR Summary:

  - broccoliBuilderErrorStack: [undefined]
  - codeFrame: [undefined]
  - errorMessage: 
  - errorType: [undefined]
  - location:
    - column: [undefined]
    - file: [undefined]
    - line: [undefined]
  - message: 
  - name: Error
  - nodeAnnotation: [undefined]
  - nodeName: [undefined]
  - originalErrorMessage: [undefined]
  - stack: Error
    at repl:1:14
    at ContextifyScript.Script.runInThisContext (vm.js:50:33)
    at REPLServer.defaultEval (repl.js:240:29)
    at bound (domain.js:301:14)
    at REPLServer.runBound [as eval] (domain.js:314:12)
    at REPLServer.onLine (repl.js:441:10)
    at emitOne (events.js:121:20)
    at REPLServer.emit (events.js:211:7)
    at REPLServer.Interface._onLine (readline.js:282:10)
    at REPLServer.Interface._line (readline.js:631:8)

=================================================================================

```

Pictures:

<img width="900" alt="screen shot 2017-11-24 at 7 06 58 pm" src="https://user-images.githubusercontent.com/1377/33226822-bab45ad6-d14a-11e7-8e35-57c9d398bbbb.png">
