### PR TITLE
Require fs to be able to write file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const chalk            = require('chalk');
 const writeError       = require('./write-error');
 const tmpdir           = require('os').tmpdir();
 const crypto           = require('crypto');
+const fs               = require('fs');
 
 const DEFAULT_WRITE_LEVEL = 'INFO';
 


### PR DESCRIPTION
`fs` is been used in the writeError method, however, we did not require it before.