### PR TITLE
Revert "fix(package): update inquirer to version 5.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "chalk": "^2.1.0",
-    "inquirer": "^5.0.0",
+    "inquirer": "^2",
     "json-stable-stringify": "^1.0.1",
     "ora": "^2.0.0",
     "through": "^2.3.8",


### PR DESCRIPTION
This reverts commit 13bf5bb612df3395e52364ea69c5d8bec614645a and PR https://github.com/ember-cli/console-ui/pull/26.

Reason: `inquirer@5` is not compatible with Node 4 (see https://github.com/SBoudrias/Inquirer.js/blob/v5.0.0/package.json#L11)

For some reason our CI system did not catch that. Most likely because npm only emits warnings instead of hard errors like yarn.

/cc @twokul