### PR TITLE
Ensure error.code is preserved from build errors

### DIFF
--- a/lib/write-error.js
+++ b/lib/write-error.js
@@ -15,6 +15,7 @@ function extractBroccoliError(error) {
 
   return {
     name: error.name,
+    code: error.code,
     message: error.message,
     stack: error.stack,
     broccoliBuilderErrorStack: broccoliPayload.error.stack,

--- a/tests/unit/write-error-test.js
+++ b/tests/unit/write-error-test.js
@@ -60,6 +60,17 @@ describe('writeError', function() {
     expect(report).to.contain('file: the file');
   });
 
+  it('error with code', function() {
+    let error = new Error();
+    error.code = 'the code';
+    let report = writeError(ui, error);
+
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.contain('Error');
+
+    expect(report).to.contain('code: the code');
+  });
+
   it('error with filename (as from Uglify)', function() {
     let report = writeError(ui, new BuildError({
       filename: 'the file'


### PR DESCRIPTION
We should also serialize the error.code property, as it commonly is actionable.