### PR TITLE
[fix] fixes an issue with through2 not returning the stream by calling async callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,9 +36,10 @@ class UI {
     let options = _options || {};
     // Output stream
     this.actualOutputStream = options.outputStream || process.stdout;
-    this.outputStream = through(function (data) {
+    this.outputStream = through(function (data, enc, callback) {
       spinner.stop();
-      this.emit('data', data);
+
+      callback(null, data);
     });
     this.outputStream.setMaxListeners(0);
     this.outputStream.pipe(this.actualOutputStream);


### PR DESCRIPTION
_This fixes #67_

# What was wrong?

- Through2 requires that you call the callback so that it knows your stream processing is done

# What is the fix?

- Calling the async callback will allow through2 to not destroy the stream due to it taking too long.

<img width="3622" alt="no-errors_combined" src="https://user-images.githubusercontent.com/1854811/55500608-82241380-55fd-11e9-856d-bb6cb34d610a.png">

_I am trying to write a test that ensures that the stream output is dealing with properly_