### PR TITLE
[test] testing through2 by upgrading mock

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -1,21 +1,25 @@
 'use strict';
 
 const UI      = require('./');
-const through = require('through');
+const through = require('through2');
 
 module.exports = class MockUI extends UI {
   constructor(options) {
     super({
       inputStream: through(),
-      outputStream: through((data) => {
+      outputStream: through((data, enc, callback) => {
         if (options && options.outputStream) {
           options.outputStream.push(data);
         }
 
         this.output += data;
+
+        callback();
       }),
-      errorStream: through((data) => {
+      errorStream: through((data, enc, callback) => {
         this.errors += data;
+
+        callback();
       })
     });
 

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -6,6 +6,10 @@ const EOL    = require('os').EOL;
 const chalk  = require('chalk');
 const fs     = require('fs');
 
+function errorLogToReportPath(log) {
+  return log.match(/([^\s]+error\.dump\.\w+\.log)/)[0];
+}
+
 describe('UI', function() {
   let ui;
 
@@ -95,10 +99,6 @@ describe('UI', function() {
     afterEach(function() {
       process.env.CI = originalCI;
     });
-
-    function errorLogToReportPath(log) {
-      return log.match(/([^\s]+error\.dump\.\w+\.log)/)[0];
-    }
 
     it('empty error', function() {
       ui.writeError({});


### PR DESCRIPTION
# What was wrong?

The testing of the output stream was still using through and not through2

# What is the fix?

Upgrading the mocks to through2 will expose the error we were previously seeing. Implementing through2 correctly as done in #68 ensures the tests will pass.