### PR TITLE
Fix `TypeError: Cannot read property stack of undefined`

### DIFF
--- a/lib/write-error.js
+++ b/lib/write-error.js
@@ -5,6 +5,7 @@ const summarizeProcess = require('./summarize-process');
 
 function extractBroccoliError(error) {
   let broccoliPayload = error.broccoliPayload || { error: {} };
+  let broccoliBuilderError = broccoliPayload.error || {};
   let broccoliNode = broccoliPayload.broccoliNode || {};
 
   let defaultLocation = {
@@ -18,14 +19,14 @@ function extractBroccoliError(error) {
     code: error.code,
     message: error.message,
     stack: error.stack,
-    broccoliBuilderErrorStack: broccoliPayload.error.stack,
+    broccoliBuilderErrorStack: broccoliBuilderError.stack,
     errorMessage: error.message,
-    originalErrorMessage: broccoliPayload.error.message,
-    codeFrame: broccoliPayload.error.codeFrame,
+    originalErrorMessage: broccoliBuilderError.message,
+    codeFrame: broccoliBuilderError.codeFrame,
     nodeName: broccoliNode.nodeName,
     nodeAnnotation: broccoliNode.nodeAnnotation,
-    errorType: broccoliPayload.error.errorType,
-    location: broccoliPayload.error.location || defaultLocation
+    errorType: broccoliBuilderError.errorType,
+    location: broccoliBuilderError.location || defaultLocation
   };
 }
 

--- a/tests/unit/write-error-test.js
+++ b/tests/unit/write-error-test.js
@@ -240,4 +240,13 @@ describe('writeError', function() {
     expect(report).to.contain('codeFrame');
     expect(report).to.contain('broccoli error message');
   });
+
+  it('error with no payload', function() {
+    writeError(ui, new BuildError({
+      broccoliPayload: {},
+    }));
+
+    expect(ui.output).to.equal('');
+    expect(ui.errors).to.equal(chalk.red('Error') + EOL + EOL);
+  });
 });


### PR DESCRIPTION
Encountered this while working on broccoli. When there is an error in babel transpilation, `error` is not present on `error.broccoliPayload`. This leads to the following error when running broccoli serve:

```
(node:45053) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'stack' of undefined
    at extractBroccoliError (/Users/siva/Home/personal/broccoli/node_modules/console-ui/lib/write-error.js:21:54)
    at writeError (/Users/siva/Home/personal/broccoli/node_modules/console-ui/lib/write-error.js:52:19)
    at UI.writeError (/Users/siva/Home/personal/broccoli/node_modules/console-ui/lib/index.js:157:20)
    at Watcher._watcher.on.err (/Users/siva/Home/personal/broccoli/lib/server.js:75:17)
    at emitOne (events.js:116:13)
    at Watcher.emit (events.js:211:7)
    at buildPromise.then.err (/Users/siva/Home/personal/broccoli/lib/watcher.js:133:14)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
(node:45053) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
``` 