### PR TITLE
Update writeError to read this.ci

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ class UI {
     this.errorLog = options.errorLog || [];
     this.writeLevel = options.writeLevel || DEFAULT_WRITE_LEVEL;
     this.errorReport = null;
-    this.ci = !!options.ci;
+    this.ci = options.ci !== undefined ? !!options.ci : !!process.env.CI;
   }
   /**
     Unified mechanism to write a string to the console.
@@ -170,7 +170,7 @@ class UI {
     }
 
     if (typeof error === 'object' && error !== null && !error.isSilentError) {
-      if (process.env.CI) {
+      if (this.ci) {
         // In CI mode we print the error details to the console directly
         this.writeLine(report, 'ERROR');
       } else {

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -20,7 +20,8 @@ module.exports = class MockUI extends UI {
         this.errors += data;
 
         callback();
-      })
+      }),
+      ci: options && options.ci
     });
 
     this.output = '';

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -116,6 +116,8 @@ describe('UI', function() {
     beforeEach(function() {
       originalCI = process.env.CI;
       delete process.env.CI;
+      // Create new ui object since we setup this.ci once in the constructor
+      ui = new MockUI();
     });
 
     afterEach(function() {
@@ -162,6 +164,35 @@ describe('UI', function() {
       expect(ui.errors).to.not.contain('Stack Trace and Error Report');
       expect(ui.errors).to.not.contain('error\.dump\.');
       expect(ui.errorLog).to.deep.eql([]);
+    });
+
+    it('respects options.ci over process.env.CI if set', function() {
+      process.env.CI = true;
+      let ciUI = new MockUI({
+        ci: false
+      });
+
+      ciUI.writeError(new Error('I AM ERROR MESSAGE'));
+      expect(ciUI.output).to.eql('');
+      expect(ciUI.errors).to.contain('I AM ERROR MESSAGE');
+      expect(ciUI.errors).to.contain('Stack Trace and Error Report');
+      expect(ciUI.errors).to.contain('error\.dump\.');
+
+      const filepath = errorLogToReportPath(ciUI.errors);
+      const report = fs.readFileSync(filepath, 'UTF8')
+
+      expect(report).to.contain('ENV Summary:');
+      expect(report).to.contain('ERROR Summary:');
+      expect(report).to.contain('I AM ERROR MESSAGE');
+
+      delete process.env.CI;
+      ciUI = new MockUI({
+        ci: true
+      });
+      ciUI.writeError(new Error('I AM ERROR MESSAGE'));
+      expect(ciUI.output).to.eql('');
+      expect(ciUI.errors).to.contain('I AM ERROR MESSAGE');
+      expect(ciUI.errors).to.not.contain('Stack Trace and Error Report');
     });
   });
 });


### PR DESCRIPTION
Swapping writeError to use options.ci instead of process.env.CI to print the full details for errors.