### PR TITLE
Spinner should respect errorStream option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,8 +32,9 @@ const DEFAULT_WRITE_LEVEL = 'INFO';
 */
 class UI {
   constructor(_options) {
-    let spinner = this.spinner = ora({ color: 'green' });
     let options = _options || {};
+    let errorStream = this.errorStream = options.errorStream || process.stderr;
+    let spinner = this.spinner = ora({ color: 'green', stream: errorStream });
     // Output stream
     this.progress = false;
     this.actualOutputStream = options.outputStream || process.stdout;
@@ -51,7 +52,6 @@ class UI {
     this.outputStream.setMaxListeners(0);
     this.outputStream.pipe(this.actualOutputStream);
     this.inputStream = options.inputStream || process.stdin;
-    this.errorStream = options.errorStream || process.stderr;
     this.errorLog = options.errorLog || [];
     this.writeLevel = options.writeLevel || DEFAULT_WRITE_LEVEL;
     this.errorReport = null;


### PR DESCRIPTION
`ora` accepts an optional `stream` argument. It defaults to stderr.

If the user has provided an alternative to `stderr` via `options.errorStream`, the spinner should follow that too.