### PR TITLE
Change the destination of warnings and deprecations to `errorStream`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ const ui = new UI({
 });
 ```
 
+available write levels:
+* DEBUG (outputStream)
+* INFO (outputStream)
+* WARNING (errorStream)
+* ERROR (errorStream)
+
 write to output:
 
 ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ class UI {
     @param {String} [writeLevel='INFO']
   */
   write(data, writeLevel) {
-    if (writeLevel === 'ERROR') {
+    if (writeLevel === 'ERROR' || writeLevel === 'WARNING') {
       this.errorStream.write(data);
     } else if (this.writeLevelVisible(writeLevel)) {
       this.outputStream.write(data);

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -62,34 +62,46 @@ describe('UI', function() {
   describe('writeWarningLine', function() {
     it('does not write when the test is truthy', function() {
       ui.writeWarnLine('foo', true);
-      expect(ui.output).to.equal('');
+      expect(ui.errors).to.equal('');
     });
 
     it('writes a prepended message when the test is falsy', function() {
       ui.writeWarnLine('foo', false);
-      expect(ui.output).to.equal(chalk.yellow('WARNING: foo') + EOL);
+      expect(ui.errors).to.equal(chalk.yellow('WARNING: foo') + EOL);
     });
 
     it('writes an un-prepended message if prepend is false', function() {
       ui.writeWarnLine('foo', false, false);
-      expect(ui.output).to.equal(chalk.yellow('foo') + EOL);
+      expect(ui.errors).to.equal(chalk.yellow('foo') + EOL);
+    });
+
+    it('writes to errorStream', function() {
+      ui.writeWarnLine('foo', false, false);
+      expect(ui.output).to.be.empty;
+      expect(ui.errors).to.equal(chalk.yellow('foo') + EOL);
     });
   });
 
   describe('writeDeprecateLine', function() {
     it('does not write when the test is truthy', function() {
       ui.writeDeprecateLine('foo', true);
-      expect(ui.output).to.equal('');
+      expect(ui.errors).to.equal('');
     });
 
     it('writes a prepended message when the test is falsy', function() {
       ui.writeDeprecateLine('foo', false);
-      expect(ui.output).to.equal(chalk.yellow('DEPRECATION: foo') + EOL);
+      expect(ui.errors).to.equal(chalk.yellow('DEPRECATION: foo') + EOL);
     });
 
     it('writes an un-prepended message if prepend is false', function() {
       ui.writeDeprecateLine('foo', false, false);
-      expect(ui.output).to.equal(chalk.yellow('foo') + EOL);
+      expect(ui.errors).to.equal(chalk.yellow('foo') + EOL);
+    });
+
+    it('writes to errorStream', function() {
+      ui.writeDeprecateLine('foo', false, false);
+      expect(ui.output).to.be.empty;
+      expect(ui.errors).to.equal(chalk.yellow('foo') + EOL);
     });
   });
 


### PR DESCRIPTION
See ember-cli/ember-cli#9416 for additional context.

This aims to change destination of output at write level `WARNING` to `errorStream` (i.e., `stderr`). Making this change should help avoid the situation where an unexpected warning or deprecation message is comingled with the "expected" output which may be being consumed by another process (e.g., piping JSON output).

I've also added a small section to the README highlighting the available write levels and their destinations.

Illustration of the proposed change:


```
# test-iu.js
const UI = require('console-iu');
const ui = new UI();

ui.writeWarnLine('this is a warning', false);
ui.writeDeprecateLine('this is a deprecation', false);
ui.writeLine('normal output');
```
```
$ node test-ui.js
WARNING: this is a warning
DEPRECATION: this is a deprecation
normal output

$ node test-ui.js >capture-stdout.txt
WARNING: this is a warning
DEPRECATION: this is a deprecation

$ node test-ui.js 2>capture-stderr.txt
normal output
```
